### PR TITLE
feat(.github): Add workflow to replicate files to repositories

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Do not trim trailing whitespace on Markdown files as double space can be used
+# for a newline
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/file_replication.yaml
+++ b/.github/workflows/file_replication.yaml
@@ -1,0 +1,47 @@
+name: Replicate Files
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  get-temp-token:
+    uses: 3ware/workflows/.github/workflows/get-workflow-token.yaml@57a900982a56bebaf91e660a56adb7f021690d15 # v4.0.0
+    secrets: inherit
+
+  replicate-files:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [get-temp-token]
+    steps:
+      - name: Decrypt the installation access token
+        id: decrypt-token
+        run: |
+          DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
+          --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
+          | base64 --decode))
+          echo "::add-mask::$DECRYPTED_TOKEN"
+          echo "temp-token=$DECRYPTED_TOKEN" >> $GITHUB_OUTPUT
+        env:
+          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          token: ${{ steps.decrypt-token.outputs.temp-token }}
+
+      - name: Replicate files
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25 # v2
+        with:
+          github_token: ${{ steps.decrypt-token.outputs.temp-token }}
+          patterns_to_include: '.releaserc.json'
+          exclude_private: true
+          exclude_forked: true
+          repos_to_ignore: 'workflows,www-src'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,57 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "breaking": true, "release": "major" },
+          { "type": "refactor", "release": "minor" },
+          { "type": "chore", "scope": "deps", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "refactor", "section": "Enhancement", "hidden": false },
+            { "type": "feat", "section": "Features", "hidden": false },
+            { "type": "fix", "section": "Bug Fixes", "hidden": false },
+            {
+              "type": "chore",
+              "scope": "deps",
+              "section": "Chores",
+              "hidden": false
+            }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version}",
+        "labels": false,
+        "releasedLabels": false
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file."
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): version ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @3ware/repo-maintainers

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,10 +12,11 @@ module.exports = {
       "always",
       [
         "commitlint",
+        ".github",
         "pr-check",
         "release",
-        "trunk",
-        "replicate"
+        "replicate",
+        "trunk"
       ],
     ],
     //"signed-off-by": [1, "always", "Signed-off-by:"],

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,45 @@
+module.exports = {
+  rules: {
+    "body-leading-blank": [1, "always"],
+    "body-max-line-length": [2, "always", 72],
+    "footer-leading-blank": [1, "always"],
+    "footer-max-line-length": [2, "always", 72],
+    "header-max-length": [2, "always", 72],
+    "scope-case": [2, "always", "lower-case"],
+    "scope-empty": [1, "never"],
+    "scope-enum": [
+      1,
+      "always",
+      [
+        "commitlint",
+        "pr-check",
+        "release",
+        "trunk",
+        "replicate"
+      ],
+    ],
+    //"signed-off-by": [1, "always", "Signed-off-by:"],
+    "subject-case": [1, "always", "sentence-case"],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
.github copies a limited number of supported files to other repositories.

https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#supported-file-types

This PR adds the initial commit of a workflow to copy other files, like config files and workflow files to other repositories.